### PR TITLE
telnet port / group id dialout

### DIFF
--- a/fhem/Dockerfile
+++ b/fhem/Dockerfile
@@ -4,6 +4,9 @@ ARG BUILD_ARCH
 FROM $BUILD_FROM
 LABEL maintainer="kastbernd@gmx.de"
 
+# make sure GID for dialout group matches "Home Assistant Operating System" (dialout:x:18:)
+RUN sed -i "s/^dialout\:.*/dialout\:x\:18/" /etc/group
+
 # Copy data for add-on
 
 COPY run.sh /

--- a/fhem/config.json
+++ b/fhem/config.json
@@ -16,10 +16,11 @@
   "apparmor": false,
   "ports": {
     "8083/tcp": 8083,
-    "23/tcp": null
+    "7072/tcp": null
   },
   "ports_description": {
-    "8083/tcp": "WebUI"
+    "8083/tcp": "WebUI",
+    "7072/tcp": "telnet"
   },
   "map": ["config:rw"],
   "host_network": false,


### PR DESCRIPTION
Dear KastB,

in order to get most out of your addon I had to do two little tweaks:
1. enabled telnet port 7072 in configuration of the addon
2. altered the gid of group dialout to match the host OS

Cheers and thank you for your work,
Oliver